### PR TITLE
feat: 특정 팀 조회 기능 구현

### DIFF
--- a/src/main/java/com/example/spartaoutsourcing/common/consts/SuccessCode.java
+++ b/src/main/java/com/example/spartaoutsourcing/common/consts/SuccessCode.java
@@ -30,6 +30,7 @@ public enum SuccessCode {
     TEAM_CREATED(201, "팀이 성공적으로 생성되었습니다."),
     TEAM_DELETED(200, "팀이 성공적으로 삭제되었습니다."),
     TEAM_UPDATE(200, "팀 정보가 성공적으로 업데이트되었습니다."),
+    TEAM_FOUND(200, "팀 정보를 조회했습니다."),
 
     // MEMBER
     MEMBER_ADDED(200, "멤버가 성공적으로 추가되었습니다."),

--- a/src/main/java/com/example/spartaoutsourcing/domain/member/dto/response/MemberResponse.java
+++ b/src/main/java/com/example/spartaoutsourcing/domain/member/dto/response/MemberResponse.java
@@ -2,6 +2,7 @@ package com.example.spartaoutsourcing.domain.member.dto.response;
 
 
 import com.example.spartaoutsourcing.domain.member.entity.Member;
+import com.example.spartaoutsourcing.domain.user.entity.User;
 import com.example.spartaoutsourcing.domain.user.enums.UserRole;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -19,6 +20,8 @@ public class MemberResponse {
     private LocalDateTime createdAt;
 
     public static MemberResponse from(Member member) {
+        User user = member.getUser();
+        if (user == null || user.getDeletedAt() != null) return null;
         return new MemberResponse(
                 member.getUser().getId(),
                 member.getUser().getUsername(),

--- a/src/main/java/com/example/spartaoutsourcing/domain/team/controller/TeamController.java
+++ b/src/main/java/com/example/spartaoutsourcing/domain/team/controller/TeamController.java
@@ -48,4 +48,12 @@ public class TeamController {
         teamService.delete(teamId);
         return GlobalApiResponse.of(SuccessCode.TEAM_DELETED, null);
     }
+
+    @GetMapping("/{teamId}")
+    public GlobalApiResponse<TeamResponse> getTeam(
+            @PathVariable Long teamId
+    ){
+        TeamResponse teamResponse = teamService.getTeamById(teamId);
+        return GlobalApiResponse.of(SuccessCode.TEAM_FOUND, teamResponse);
+    }
 }

--- a/src/main/java/com/example/spartaoutsourcing/domain/team/dto/response/TeamResponse.java
+++ b/src/main/java/com/example/spartaoutsourcing/domain/team/dto/response/TeamResponse.java
@@ -25,6 +25,7 @@ public class TeamResponse {
                 team.getDescription(),
                 team.getCreatedAt(),
                 team.getMembers().stream()
+                        .filter(member -> member.getDeletedAt()==null)
                         .map(MemberResponse::from)
                         .toList()
         );

--- a/src/main/java/com/example/spartaoutsourcing/domain/team/service/TeamService.java
+++ b/src/main/java/com/example/spartaoutsourcing/domain/team/service/TeamService.java
@@ -11,13 +11,16 @@ import com.example.spartaoutsourcing.domain.team.entity.Team;
 import com.example.spartaoutsourcing.domain.team.repository.TeamRepository;
 import com.example.spartaoutsourcing.domain.user.entity.User;
 import com.example.spartaoutsourcing.domain.user.repository.UserRepository;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.jpa.domain.AbstractAuditable_;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
@@ -87,5 +90,17 @@ public class TeamService {
         return teamRepository.findTeamsByKeyword(keyword);
     }
 
+    @Transactional(readOnly = true)
+    public TeamResponse getTeamById(Long teamId){
+        Team team = teamRepository.findById(teamId)
+                .orElseThrow(() -> new GlobalException(ErrorCode.TEAM_NOT_FOUND));
+
+        List<MemberResponse> memberResponses = team.getMembers().stream()
+                .map(MemberResponse::from)
+                .filter(Objects::nonNull)
+                .toList();
+
+        return TeamResponse.from(team);
+    }
 
 }


### PR DESCRIPTION
✨어떤 기능인가요?
팀 ID를 기반으로 특정 팀 정보를 조회하고, 해당 팀에 속한 팀원 목록을 함께 반환하는 기능

✔️TODOS
- 팀 ID로 팀 엔티티 조회
- 팀에 속한 멤버 목록 조회 (탈퇴한 멤버 제외)
- 조회 결과를 API 응답 형식에 맞춰 반환